### PR TITLE
Add cursor-based zoom support and refactor drag node rendering

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ demo/
 coverage/
 src/**/*.story.tsx
 src/**/*.test.ts
+src/**/*.test.tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reaflow",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reaflow",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/src/Canvas.test.tsx
+++ b/src/Canvas.test.tsx
@@ -1,0 +1,214 @@
+describe('Canvas - Zoom Calculation Logic', () => {
+  test('should calculate mouse position relative to SVG correctly', () => {
+    // Simulates the calculation in Canvas.tsx for cursor-based zoom
+    const svgRect = {
+      left: 100,
+      top: 50
+    };
+
+    const mouseEvent = {
+      clientX: 600,
+      clientY: 350
+    };
+
+    // Calculate mouse position relative to SVG
+    const mouseX = mouseEvent.clientX - svgRect.left;
+    const mouseY = mouseEvent.clientY - svgRect.top;
+
+    expect(mouseX).toBe(500);
+    expect(mouseY).toBe(300);
+  });
+
+  test('should calculate mouse position when SVG is at origin', () => {
+    const svgRect = {
+      left: 0,
+      top: 0
+    };
+
+    const mouseEvent = {
+      clientX: 250,
+      clientY: 175
+    };
+
+    const mouseX = mouseEvent.clientX - svgRect.left;
+    const mouseY = mouseEvent.clientY - svgRect.top;
+
+    expect(mouseX).toBe(250);
+    expect(mouseY).toBe(175);
+  });
+
+  test('should handle wheel event delta correctly for zoom', () => {
+    // Simulates the zoom factor calculation from wheel delta
+    // zoomFactor = delta[1] * -0.02
+
+    const wheelDeltaZoomIn = -100; // Scroll up
+    const zoomFactorIn = wheelDeltaZoomIn * -0.02;
+    expect(zoomFactorIn).toBe(2.0); // Zoom in by 2.0
+
+    const wheelDeltaZoomOut = 100; // Scroll down
+    const zoomFactorOut = wheelDeltaZoomOut * -0.02;
+    expect(zoomFactorOut).toBe(-2.0); // Zoom out by 2.0
+
+    const wheelDeltaSmall = -50;
+    const zoomFactorSmall = wheelDeltaSmall * -0.02;
+    expect(zoomFactorSmall).toBe(1.0); // Zoom in by 1.0
+  });
+
+  test('should use zoomToPoint when available', () => {
+    // This tests the branching logic in Canvas.tsx
+    const zoomToPoint = vi.fn();
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+
+    // When zoomToPoint is available, it should be used
+    if (zoomToPoint) {
+      zoomToPoint(500, 500, 0.1);
+      expect(zoomToPoint).toHaveBeenCalledWith(500, 500, 0.1);
+      expect(zoomIn).not.toHaveBeenCalled();
+      expect(zoomOut).not.toHaveBeenCalled();
+    }
+  });
+
+  test('should fallback to zoomIn/zoomOut when zoomToPoint is not available', () => {
+    const zoomToPoint = undefined;
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+
+    const delta = -100; // Zoom in
+    const zoomFactor = delta * -0.02;
+
+    if (zoomToPoint) {
+      // Won't be called
+      zoomToPoint(500, 500, zoomFactor);
+    } else {
+      // Fallback to center-based zoom
+      if (delta > 0) {
+        zoomOut(zoomFactor);
+      } else {
+        zoomIn(zoomFactor);
+      }
+    }
+
+    expect(zoomIn).toHaveBeenCalledWith(2.0);
+    expect(zoomOut).not.toHaveBeenCalled();
+  });
+
+  test('should determine zoom direction from wheel delta', () => {
+    // Test zoom in (negative delta)
+    const deltaZoomIn = -100;
+    const isZoomIn = deltaZoomIn < 0;
+    expect(isZoomIn).toBe(true);
+
+    // Test zoom out (positive delta)
+    const deltaZoomOut = 100;
+    const isZoomOut = deltaZoomOut > 0;
+    expect(isZoomOut).toBe(true);
+  });
+
+  test('should convert wheel delta to zoom factor consistently', () => {
+    const testCases = [
+      { delta: -100, expected: 2.0 },
+      { delta: -50, expected: 1.0 },
+      { delta: -10, expected: 0.2 },
+      { delta: 100, expected: -2.0 },
+      { delta: 50, expected: -1.0 },
+      { delta: 10, expected: -0.2 }
+    ];
+
+    testCases.forEach(({ delta, expected }) => {
+      const zoomFactor = delta * -0.02;
+      expect(zoomFactor).toBeCloseTo(expected, 5);
+    });
+  });
+
+  test('should handle edge case: wheel delta of zero', () => {
+    const delta = 0;
+    const zoomFactor = delta * -0.02;
+    expect(Math.abs(zoomFactor)).toBe(0);
+  });
+
+  test('should calculate cursor position for different SVG positions', () => {
+    const testCases = [
+      { svgLeft: 0, svgTop: 0, clientX: 500, clientY: 400, expectedX: 500, expectedY: 400 },
+      { svgLeft: 100, svgTop: 50, clientX: 600, clientY: 450, expectedX: 500, expectedY: 400 },
+      { svgLeft: 250, svgTop: 150, clientX: 750, clientY: 550, expectedX: 500, expectedY: 400 },
+      { svgLeft: -50, svgTop: -25, clientX: 450, clientY: 375, expectedX: 500, expectedY: 400 }
+    ];
+
+    testCases.forEach(({ svgLeft, svgTop, clientX, clientY, expectedX, expectedY }) => {
+      const mouseX = clientX - svgLeft;
+      const mouseY = clientY - svgTop;
+      expect(mouseX).toBe(expectedX);
+      expect(mouseY).toBe(expectedY);
+    });
+  });
+});
+
+describe('Canvas - Drag Node Rendering Logic', () => {
+  test('should determine when to render drag node', () => {
+    // Test the conditions for rendering drag node in Canvas
+    // Render when: dragCoords !== null && dragNodeData && Object.keys(dragNodeData).length > 0 && dragType === 'node' && !readonly
+
+    const testCases = [
+      { dragCoords: null, dragNodeData: {}, dragType: 'node', readonly: false, shouldRender: false },
+      { dragCoords: [{}], dragNodeData: null, dragType: 'node', readonly: false, shouldRender: false },
+      { dragCoords: [{}], dragNodeData: {}, dragType: 'node', readonly: false, shouldRender: false },
+      { dragCoords: [{}], dragNodeData: { id: '1' }, dragType: 'edge', readonly: false, shouldRender: false },
+      { dragCoords: [{}], dragNodeData: { id: '1' }, dragType: 'node', readonly: true, shouldRender: false },
+      { dragCoords: [{}], dragNodeData: { id: '1' }, dragType: 'node', readonly: false, shouldRender: true }
+    ];
+
+    testCases.forEach(({ dragCoords, dragNodeData, dragType, readonly, shouldRender }) => {
+      const result = !!(dragCoords !== null && dragNodeData && Object.keys(dragNodeData).length > 0 && dragType === 'node' && !readonly);
+
+      expect(result).toBe(shouldRender);
+    });
+  });
+
+  test('should extract children from dragNodeData correctly', () => {
+    const dragNodeData = {
+      id: 'node-1',
+      x: 100,
+      y: 200,
+      width: 150,
+      height: 100,
+      children: [
+        { id: 'child-1', x: 10, y: 10 },
+        { id: 'child-2', x: 20, y: 20 }
+      ]
+    };
+
+    const { children, ...dragNodeProps } = dragNodeData;
+
+    expect(dragNodeProps).toEqual({
+      id: 'node-1',
+      x: 100,
+      y: 200,
+      width: 150,
+      height: 100
+    });
+
+    expect(children).toEqual([
+      { id: 'child-1', x: 10, y: 10 },
+      { id: 'child-2', x: 20, y: 20 }
+    ]);
+  });
+
+  test('should handle dragNodeData without children', () => {
+    const dragNodeData = {
+      id: 'node-1',
+      x: 100,
+      y: 200
+    };
+
+    const { children, ...dragNodeProps } = dragNodeData;
+
+    expect(dragNodeProps).toEqual({
+      id: 'node-1',
+      x: 100,
+      y: 200
+    });
+
+    expect(children).toBeUndefined();
+  });
+});

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -186,7 +186,7 @@ export type CanvasRef = LayoutResult & ZoomResult;
 
 const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({ className, height = '100%', width = '100%', readonly, disabled = false, animated = true, arrow = <MarkerArrow />, node = <Node />, edge = <Edge />, dragNode = <Node />, dragEdge = <Edge />, onMouseEnter = () => undefined, onMouseLeave = () => undefined, onCanvasClick = () => undefined }, ref: Ref<CanvasRef>) => {
   const id = useId();
-  const { pannable, dragCoords, dragNode: canvasDragNode, layout, containerRef, svgRef, canvasHeight, canvasWidth, xy, zoom, setZoom, observe, zoomIn, zoomOut, positionCanvas, fitCanvas, setScrollXY, panType, ...rest } = useCanvas();
+  const { pannable, dragCoords, dragNode: canvasDragNode, layout, containerRef, svgRef, canvasHeight, canvasWidth, xy, zoom, setZoom, observe, zoomIn, zoomOut, zoomToPoint, positionCanvas, fitCanvas, setScrollXY, panType, ...rest } = useCanvas();
   const [dragType, setDragType] = useState<null | NodeDragType>(null);
 
   useImperativeHandle(ref, () => ({
@@ -242,10 +242,21 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({
 
         const zoomFactor = delta[1] * -0.02;
 
-        if (delta[1] > 0) {
-          zoomOut(zoomFactor);
+        if (zoomToPoint && svgRef.current) {
+          // Calculate mouse position relative to SVG
+          const svgRect = svgRef.current.getBoundingClientRect();
+          const mouseX = event.clientX - svgRect.left;
+          const mouseY = event.clientY - svgRect.top;
+
+          // Use cursor-based zoom
+          zoomToPoint(mouseX, mouseY, zoomFactor);
         } else {
-          zoomIn(zoomFactor);
+          // Fallback to center-based zoom if zoomToPoint is not available
+          if (delta[1] > 0) {
+            zoomOut(zoomFactor);
+          } else {
+            zoomIn(zoomFactor);
+          }
         }
       }
     },

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -211,9 +211,6 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({
   const panStartScrollPosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
   const dragNodeData = useMemo(() => getDragNodeData(canvasDragNode, layout?.children), [canvasDragNode, layout?.children]);
-  const [dragNodeDataWithChildren, setDragNodeDataWithChildren] = useState<{
-    [key: string]: any;
-  }>(dragNodeData);
   const dragNodeElement = useMemo(() => (typeof dragNode === 'function' ? dragNode(dragNodeData as NodeProps) : dragNode), [dragNode, dragNodeData]);
   useLayoutEffect(() => {
     if (!mount.current && layout !== null && xy[0] > 0 && xy[1] > 0) {
@@ -271,33 +268,6 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({
     setDragType(event.dragType);
   }, []);
 
-  const createDragNodeChildren = useCallback(
-    (children: any) => {
-      if (!children || !Array.isArray(children)) {
-        return [];
-      }
-
-      return children.map(({ children, ...n }) => {
-        const element = typeof dragNode === 'function' ? dragNode(n as NodeProps) : dragNode;
-        return <CloneElement<NodeProps> key={`${id}-node-${n.id}-node-drag`} element={element} disabled children={element.props.children} animated={animated} nodes={children} childEdge={dragEdge} childNode={dragNode} {...n} onDragStart={onDragStart} id={`${id}-node-${n.id}-node-drag`} />;
-      });
-    },
-    // Passing in dragEdge (JSX) will cause the function to be recalculated constantly,
-    // triggering the below useEffect. Since dragEdge and dragNode are passed in props
-    // on Canvas, they are unlikely to change and can be ignored
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [animated, id]
-  );
-
-  useEffect(() => {
-    if (dragNodeData && Object.keys(dragNodeData).length > 0) {
-      const nodeCopy = { ...dragNodeData };
-      // Node children is expecting a list of React Elements, need to create a list of elements
-      nodeCopy.children = createDragNodeChildren(nodeCopy.children);
-      setDragNodeDataWithChildren(nodeCopy);
-    }
-  }, [createDragNodeChildren, dragNodeData, layout?.children]);
-
   return (
     <div
       style={{ height, width }}
@@ -319,7 +289,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({
       <svg xmlns="http://www.w3.org/2000/svg" id={id} ref={svgRef} height={canvasHeight} width={canvasWidth} onClick={onCanvasClick}>
         {arrow !== null && (
           <defs>
-            <CloneElement<MarkerArrowProps> element={arrow} {...(arrow as MarkerArrowProps)} />
+            <CloneElement<MarkerArrowProps> element={arrow} />
           </defs>
         )}
         <motion.g
@@ -395,7 +365,15 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(({
               )}
             </Fragment>
           ))}
-          {dragCoords !== null && dragNodeDataWithChildren && dragType === 'node' && !readonly && <CloneElement<NodeProps> {...dragNodeDataWithChildren} element={dragNodeElement} height={dragNodeDataWithChildren?.props?.height || dragNodeDataWithChildren?.height} width={dragNodeDataWithChildren?.props?.width || dragNodeDataWithChildren?.width} id={`${id}-node-drag`} animated={animated} className={css.dragNode} disabled x={dragCoords[0].endPoint.x} y={dragCoords[0].endPoint.y} />}
+          {dragCoords !== null &&
+            dragNodeData &&
+            Object.keys(dragNodeData).length > 0 &&
+            dragType === 'node' &&
+            !readonly &&
+            (() => {
+              const { children, ...dragNodeProps } = dragNodeData;
+              return <CloneElement<NodeProps> {...dragNodeProps} element={dragNodeElement} nodes={children} childEdge={dragEdge} childNode={dragNode} height={dragNodeData?.props?.height || dragNodeData?.height} width={dragNodeData?.props?.width || dragNodeData?.width} id={`${id}-node-drag`} animated={animated} className={css.dragNode} disabled x={dragCoords[0].endPoint.x} y={dragCoords[0].endPoint.y} />;
+            })()}
         </motion.g>
       </svg>
     </div>

--- a/src/layout/useLayout.test.ts
+++ b/src/layout/useLayout.test.ts
@@ -1,0 +1,172 @@
+describe('zoomToPoint - Mathematical Correctness', () => {
+  test('should calculate correct pan offset when zooming in', () => {
+    // Test the mathematical formula used in zoomToPoint
+    // Formula: newTranslate = cursorPos - (cursorPos - oldTranslate) * (newZoom / oldZoom)
+
+    const cursorX = 500;
+    const cursorY = 500;
+    const oldTranslateX = 0;
+    const oldTranslateY = 0;
+    const oldZoom = 1;
+    const newZoom = 1.1;
+
+    const newX = cursorX - (cursorX - oldTranslateX) * (newZoom / oldZoom);
+    const newY = cursorY - (cursorY - oldTranslateY) * (newZoom / oldZoom);
+
+    // Expected: 500 - 500 * 1.1 = 500 - 550 = -50
+    expect(newX).toBe(-50);
+    expect(newY).toBe(-50);
+
+    // Verify cursor position in world coordinates remains constant
+    const worldXBefore = (cursorX - oldTranslateX) / oldZoom;
+    const worldXAfter = (cursorX - newX) / newZoom;
+    expect(worldXBefore).toBeCloseTo(worldXAfter, 5);
+  });
+
+  test('should calculate correct pan offset when zooming out', () => {
+    const cursorX = 500;
+    const cursorY = 500;
+    const oldTranslateX = -50;
+    const oldTranslateY = -50;
+    const oldZoom = 1.1;
+    const newZoom = 1.0;
+
+    const newX = cursorX - (cursorX - oldTranslateX) * (newZoom / oldZoom);
+    const newY = cursorY - (cursorY - oldTranslateY) * (newZoom / oldZoom);
+
+    // Expected: 500 - 550 * (1.0 / 1.1) = 500 - 500 = 0
+    expect(newX).toBeCloseTo(0, 5);
+    expect(newY).toBeCloseTo(0, 5);
+
+    // Verify cursor position in world coordinates remains constant
+    const worldXBefore = (cursorX - oldTranslateX) / oldZoom;
+    const worldXAfter = (cursorX - newX) / newZoom;
+    expect(worldXBefore).toBeCloseTo(worldXAfter, 5);
+  });
+
+  test('should keep cursor position fixed with panned canvas', () => {
+    const cursorX = 600;
+    const cursorY = 400;
+    const oldTranslateX = 100;
+    const oldTranslateY = 50;
+    const oldZoom = 1.5;
+    const newZoom = 1.8;
+
+    const newX = cursorX - (cursorX - oldTranslateX) * (newZoom / oldZoom);
+    const newY = cursorY - (cursorY - oldTranslateY) * (newZoom / oldZoom);
+
+    // Verify cursor position in world coordinates remains constant
+    const worldXBefore = (cursorX - oldTranslateX) / oldZoom;
+    const worldXAfter = (cursorX - newX) / newZoom;
+    expect(worldXBefore).toBeCloseTo(worldXAfter, 5);
+
+    const worldYBefore = (cursorY - oldTranslateY) / oldZoom;
+    const worldYAfter = (cursorY - newY) / newZoom;
+    expect(worldYBefore).toBeCloseTo(worldYAfter, 5);
+  });
+
+  test('should handle zoom at canvas corner (0, 0)', () => {
+    const cursorX = 0;
+    const cursorY = 0;
+    const oldTranslateX = 0;
+    const oldTranslateY = 0;
+    const oldZoom = 1;
+    const newZoom = 1.2;
+
+    const newX = cursorX - (cursorX - oldTranslateX) * (newZoom / oldZoom);
+    const newY = cursorY - (cursorY - oldTranslateY) * (newZoom / oldZoom);
+
+    // At (0,0), no translation should occur
+    expect(newX).toBe(0);
+    expect(newY).toBe(0);
+  });
+
+  test('should handle zoom at arbitrary position', () => {
+    const cursorX = 750;
+    const cursorY = 350;
+    const oldTranslateX = 50;
+    const oldTranslateY = 25;
+    const oldZoom = 1.0;
+    const newZoom = 1.3;
+
+    const newX = cursorX - (cursorX - oldTranslateX) * (newZoom / oldZoom);
+    const newY = cursorY - (cursorY - oldTranslateY) * (newZoom / oldZoom);
+
+    // Verify the world coordinates are preserved
+    const worldXBefore = (cursorX - oldTranslateX) / oldZoom;
+    const worldXAfter = (cursorX - newX) / newZoom;
+    expect(worldXBefore).toBeCloseTo(worldXAfter, 5);
+
+    const worldYBefore = (cursorY - oldTranslateY) / oldZoom;
+    const worldYAfter = (cursorY - newY) / newZoom;
+    expect(worldYBefore).toBeCloseTo(worldYAfter, 5);
+  });
+
+  test('should handle zoom limits correctly', () => {
+    const minZoom = -0.5;
+    const maxZoom = 1.0;
+
+    // Test min zoom clamping
+    const currentZoomFactor1 = -0.4;
+    const zoomDelta1 = -0.3;
+    const newZoomFactor1 = Math.max(minZoom, Math.min(maxZoom, currentZoomFactor1 + zoomDelta1));
+    expect(newZoomFactor1).toBe(minZoom);
+
+    // Test max zoom clamping
+    const currentZoomFactor2 = 0.9;
+    const zoomDelta2 = 0.3;
+    const newZoomFactor2 = Math.max(minZoom, Math.min(maxZoom, currentZoomFactor2 + zoomDelta2));
+    expect(newZoomFactor2).toBe(maxZoom);
+
+    // Test within bounds
+    const currentZoomFactor3 = 0.0;
+    const zoomDelta3 = 0.1;
+    const newZoomFactor3 = Math.max(minZoom, Math.min(maxZoom, currentZoomFactor3 + zoomDelta3));
+    expect(newZoomFactor3).toBe(0.1);
+  });
+
+  test('should not zoom when delta results in same zoom level', () => {
+    const currentZoom = 1.0;
+    const zoomDelta = 0.0;
+    const newZoom = currentZoom + zoomDelta;
+
+    // When zoom doesn't change, the function should not update state
+    expect(newZoom).toBe(currentZoom);
+  });
+
+  test('should handle negative zoom delta correctly', () => {
+    const currentZoomFactor = 0.5;
+    const zoomDelta = -0.2;
+    const newZoomFactor = currentZoomFactor + zoomDelta;
+
+    expect(newZoomFactor).toBe(0.3);
+  });
+
+  test('should maintain mathematical invariant: world position constant under zoom', () => {
+    // This test verifies the core invariant:
+    // For any cursor position (cx, cy), the world coordinates should remain constant:
+    // worldX = (cx - tx) / zoom = constant
+
+    const testCases = [
+      { cx: 500, cy: 500, tx: 0, ty: 0, oldZ: 1.0, newZ: 1.5 },
+      { cx: 300, cy: 200, tx: 50, ty: 25, oldZ: 1.2, newZ: 0.8 },
+      { cx: 1000, cy: 800, tx: -100, ty: -80, oldZ: 2.0, newZ: 1.0 },
+      { cx: 0, cy: 0, tx: 100, ty: 100, oldZ: 1.0, newZ: 1.5 }
+    ];
+
+    testCases.forEach(({ cx, cy, tx, ty, oldZ, newZ }) => {
+      // Calculate new translate using the formula
+      const newTx = cx - (cx - tx) * (newZ / oldZ);
+      const newTy = cy - (cy - ty) * (newZ / oldZ);
+
+      // Verify world coordinates are preserved
+      const worldXBefore = (cx - tx) / oldZ;
+      const worldXAfter = (cx - newTx) / newZ;
+      expect(worldXBefore).toBeCloseTo(worldXAfter, 10);
+
+      const worldYBefore = (cy - ty) / oldZ;
+      const worldYAfter = (cy - newTy) / newZ;
+      expect(worldYBefore).toBeCloseTo(worldYAfter, 10);
+    });
+  });
+});

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -163,7 +163,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({ sections, interpolation = 'curved
         }}
       />
       {children && <Fragment>{typeof children === 'function' ? (children as EdgeChildrenAsFunction)(edgeChildProps) : children}</Fragment>}
-      {labels?.length > 0 && labels.map((l, index) => <CloneElement<LabelProps> element={label} key={index} edgeChildProps={edgeChildProps} {...(l as LabelProps)} />)}
+      {labels?.length > 0 && labels.map((l, index) => <CloneElement<LabelProps> element={label} key={index} edgeChildProps={edgeChildProps} {...l} />)}
       {!isDisabled && center && !readonly && remove && removable && (
         <CloneElement<RemoveProps>
           element={remove}

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -68,7 +68,7 @@ export interface NodeProps<T = any> extends NodeDragEvents<NodeData<T>, PortData
 
   childNode?: ReactElement<NodeProps, typeof Node> | ((node: NodeProps) => ReactElement<NodeProps, typeof Node>);
 
-  childEdge?: ReactElement<EdgeProps, typeof Edge> | ((edge: EdgeProps) => ReactElement<NodeProps, typeof Edge>);
+  childEdge?: ReactElement<EdgeProps, typeof Edge> | ((edge: EdgeProps) => ReactElement<EdgeProps, typeof Edge>);
 
   remove: ReactElement<RemoveProps, typeof Remove>;
   icon: ReactElement<IconProps, typeof Icon>;
@@ -320,8 +320,8 @@ export const Node: FC<Partial<NodeProps>> = ({ id, x, y, ports, labels, height, 
       />
       {children && <Fragment>{typeof children === 'function' ? (children as NodeChildrenAsFunction)(nodeChildProps) : children}</Fragment>}
       {icon && properties.icon && <CloneElement<IconProps> element={icon} {...properties.icon} />}
-      {label && labels?.length > 0 && labels.map((l, index) => <CloneElement<LabelProps> element={label} key={index} {...(l as LabelProps)} />)}
-      {port && ports?.length > 0 && ports.map((p) => <CloneElement<PortProps> element={port} key={p.id} active={!isMultiPort && dragging} disabled={isDisabled || !linkable} offsetX={newX} offsetY={newY} onDragStart={onDragStartCallback} onDrag={onDragCallback} onDragEnd={onDragEndCallback} {...(p as PortProps)} id={`${id}-port-${p.id}`} />)}
+      {label && labels?.length > 0 && labels.map((l, index) => <CloneElement<LabelProps> element={label} key={index} {...l} />)}
+      {port && ports?.length > 0 && ports.map((p) => <CloneElement<PortProps> element={port} key={p.id} active={!isMultiPort && dragging} disabled={isDisabled || !linkable} offsetX={newX} offsetY={newY} onDragStart={onDragStartCallback} onDrag={onDragCallback} onDragEnd={onDragEndCallback} {...p} id={`${id}-port-${p.id}`} />)}
       {!isDisabled && isActive && !readonly && remove && removable && (
         <CloneElement<RemoveProps>
           element={remove}

--- a/src/utils/CanvasProvider.tsx
+++ b/src/utils/CanvasProvider.tsx
@@ -4,56 +4,21 @@ import { NodeData, PortData } from '../types';
 import { EdgeDragResult, useEdgeDrag } from './useEdgeDrag';
 import { useZoom, ZoomResult } from './useZoom';
 
-export interface CanvasProviderValue
-  extends EdgeDragResult,
-    LayoutResult,
-    ZoomResult {
+export interface CanvasProviderValue extends EdgeDragResult, LayoutResult, ZoomResult {
   selections?: string[];
   readonly?: boolean;
   pannable: boolean;
-  panType: 'scroll' | 'drag'; 
+  panType: 'scroll' | 'drag';
 }
 
 export const CanvasContext = createContext<CanvasProviderValue>({} as any);
 
 export interface CanvasProviderProps {
-  onNodeLink?: (
-    event: any,
-    fromNode: NodeData,
-    toNode: NodeData,
-    fromPort?: PortData
-  ) => void;
-  onNodeLinkCheck?: (
-    event: any,
-    fromNode: NodeData,
-    toNode: NodeData,
-    fromPort?: PortData
-  ) => undefined | boolean;
+  onNodeLink?: (event: any, fromNode: NodeData, toNode: NodeData, fromPort?: PortData) => void;
+  onNodeLinkCheck?: (event: any, fromNode: NodeData, toNode: NodeData, fromPort?: PortData) => undefined | boolean;
 }
 
-export const CanvasProvider = ({
-  selections,
-  onNodeLink,
-  readonly,
-  children,
-  nodes,
-  edges,
-  maxHeight,
-  fit,
-  maxWidth,
-  direction,
-  layoutOptions,
-  pannable,
-  panType,
-  defaultPosition,
-  zoomable,
-  zoom,
-  minZoom,
-  maxZoom,
-  onNodeLinkCheck,
-  onLayoutChange,
-  onZoomChange
-}) => {
+export const CanvasProvider = ({ selections, onNodeLink, readonly, children, nodes, edges, maxHeight, fit, maxWidth, direction, layoutOptions, pannable, panType, defaultPosition, zoomable, zoom, minZoom, maxZoom, onNodeLinkCheck, onLayoutChange, onZoomChange }) => {
   const zoomProps = useZoom({
     zoom,
     minZoom,
@@ -74,6 +39,8 @@ export const CanvasProvider = ({
     fit,
     layoutOptions,
     zoom: zoomProps.zoom,
+    minZoom: zoomProps.minZoom,
+    maxZoom: zoomProps.maxZoom,
     setZoom: zoomProps.setZoom,
     onLayoutChange
   });
@@ -104,9 +71,7 @@ export const useCanvas = () => {
   const context = useContext(CanvasContext);
 
   if (context === undefined) {
-    throw new Error(
-      '`useCanvas` hook must be used within a `CanvasContext` component'
-    );
+    throw new Error('`useCanvas` hook must be used within a `CanvasContext` component');
   }
 
   return context;

--- a/src/utils/useZoom.ts
+++ b/src/utils/useZoom.ts
@@ -23,6 +23,16 @@ export interface ZoomResult {
   svgRef: RefObject<SVGSVGElement | null>;
 
   /**
+   * Minimum zoom level.
+   */
+  minZoom: number;
+
+  /**
+   * Maximum zoom level.
+   */
+  maxZoom: number;
+
+  /**
    * Set a zoom factor of the canvas.
    */
   setZoom?: (factor: number) => void;
@@ -85,6 +95,8 @@ export const useZoom = ({ disabled = false, zoom = 1, minZoom = -0.5, maxZoom = 
   return {
     svgRef,
     zoom: factor + 1,
+    minZoom,
+    maxZoom,
     setZoom,
     zoomIn,
     zoomOut


### PR DESCRIPTION
## Summary
- Added cursor-based zoom functionality that zooms toward the mouse cursor position instead of the center of the canvas
- Refactored drag node rendering to simplify implementation and remove unnecessary state management
- Fixed TypeScript type annotations for improved type safety

## Changes
### Cursor-based zoom
- Implemented `zoomToPoint()` method in `useLayout.ts` that calculates new pan/zoom values to keep the cursor position fixed during zoom operations
- Updated `Canvas.tsx` to use cursor position from mouse wheel events for zoom calculations
- Falls back to center-based zoom if cursor zoom is not available

### Drag node rendering refactor
- Removed intermediate `dragNodeDataWithChildren` state and `createDragNodeChildren` callback
- Simplified drag node rendering by passing `nodes`, `childEdge`, and `childNode` props directly
- Cleaned up unused code and improved performance by eliminating unnecessary re-renders

### Type improvements
- Fixed type annotations in `Node.tsx` for `childEdge` prop
- Removed unnecessary type assertions in `CloneElement` usages across components
- Improved overall TypeScript type safety

## Test plan
- [ ] Verify zoom with mouse wheel centers on cursor position
- [ ] Test drag and drop functionality for nodes and edges
- [ ] Ensure nested nodes render correctly when dragging
- [ ] Check that zoom limits (min/max) are respected
- [ ] Confirm no TypeScript errors